### PR TITLE
Feature/bitwise operators

### DIFF
--- a/macro/src/generate.rs
+++ b/macro/src/generate.rs
@@ -571,6 +571,8 @@ const CHECKED_OPERATORS: &[CheckedOperator] = &checked_operators! {
     /** negation               */ fn neg        (    ) SignedSaturating,
     /** absolute value         */ fn abs        (    ) Signed          ,
     /** exponentiation         */ fn pow        (u32 ) All             ,
+    /** shift left             */ fn shl        (u32) NoSaturating    ,
+    /** shift right            */ fn shr        (u32) NoSaturating    ,
 };
 
 fn generate_ops_traits(item: &BoundedInteger, tokens: &mut TokenStream) {

--- a/macro/src/generate.rs
+++ b/macro/src/generate.rs
@@ -734,12 +734,18 @@ fn unop_trait_variations(
 
 #[rustfmt::skip]
 const OPERATORS: &[Operator] = &[
-    Operator { trait_name: "Add", method: "add", description: "add"           , bin: true , on_unsigned: true  },
-    Operator { trait_name: "Sub", method: "sub", description: "subtract"      , bin: true , on_unsigned: true  },
-    Operator { trait_name: "Mul", method: "mul", description: "multiply"      , bin: true , on_unsigned: true  },
-    Operator { trait_name: "Div", method: "div", description: "divide"        , bin: true , on_unsigned: true  },
-    Operator { trait_name: "Rem", method: "rem", description: "take remainder", bin: true , on_unsigned: true  },
-    Operator { trait_name: "Neg", method: "neg", description: "negate"        , bin: false, on_unsigned: false },
+    Operator { trait_name: "Add"   , method: "add"   , description: "add"           , bin: true , on_unsigned: true  },
+    Operator { trait_name: "Sub"   , method: "sub"   , description: "subtract"      , bin: true , on_unsigned: true  },
+    Operator { trait_name: "Mul"   , method: "mul"   , description: "multiply"      , bin: true , on_unsigned: true  },
+    Operator { trait_name: "Div"   , method: "div"   , description: "divide"        , bin: true , on_unsigned: true  },
+    Operator { trait_name: "Rem"   , method: "rem"   , description: "take remainder", bin: true , on_unsigned: true  },
+    Operator { trait_name: "Neg"   , method: "neg"   , description: "negate"        , bin: false, on_unsigned: false },
+    Operator { trait_name: "Not"   , method: "not"   , description: "not"           , bin: false, on_unsigned: true },
+    Operator { trait_name: "BitAnd", method: "bitand", description: "binary and"    , bin: true , on_unsigned: true  },
+    Operator { trait_name: "BitOr" , method: "bitor" , description: "binary or"     , bin: true , on_unsigned: true  },
+    Operator { trait_name: "BitXor", method: "bitxor", description: "binary xor"    , bin: true , on_unsigned: true  },
+    Operator { trait_name: "Shl"   , method: "shl"   , description: "shift left"    , bin: true , on_unsigned: true  },
+    Operator { trait_name: "Shr"   , method: "shr"   , description: "shift right"   , bin: true , on_unsigned: true  },
 ];
 
 struct Operator {

--- a/src/types.rs
+++ b/src/types.rs
@@ -508,6 +508,24 @@ macro_rules! define_bounded_integers {
             }
         )?
 
+        use core::ops::Not;
+
+        impl<const MIN: Inner, const MAX: Inner> Not for Bounded<MIN, MAX> {
+            type Output = Self;
+            #[inline]
+            fn not(self) -> Self::Output {
+                Self::new(!self.get())
+                    .expect("Attempted to negate out of range")
+            }
+        }
+        impl<const MIN: Inner, const MAX: Inner> Not for &Bounded<MIN, MAX> {
+            type Output = Bounded<MIN, MAX>;
+            #[inline]
+            fn not(self) -> Self::Output {
+                !*self
+            }
+        }
+
         // === Comparisons ===
 
         impl<const MIN: Inner, const MAX: Inner> PartialEq<Inner> for Bounded<MIN, MAX> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1133,6 +1133,8 @@ macro_rules! define_bounded_integers {
                             checked_rem
                             checked_rem_euclid
                             checked_pow
+                            checked_shl
+                            checked_shr
                         )
                     }
                 }
@@ -1200,7 +1202,7 @@ macro_rules! define_bounded_integers {
             fn num() {
                 use num_traits02::{
                     Bounded, AsPrimitive, FromPrimitive, NumCast, ToPrimitive, CheckedAdd,
-                    CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub
+                    CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, CheckedShl, CheckedShr
                 };
 
                 type B = super::Bounded<2, 8>;
@@ -1330,6 +1332,12 @@ macro_rules! define_bounded_integers {
 
                 assert_eq!(<B as CheckedSub>::checked_sub(&b(4), &b(2)), Some(b(2)));
                 assert_eq!(<B as CheckedSub>::checked_sub(&b(4), &b(4)), None);
+
+                assert_eq!(<B as CheckedShl>::checked_shl(&b(4), 1u32), Some(b(8)));
+                assert_eq!(<B as CheckedShl>::checked_shl(&b(4), 2u32), None);
+
+                assert_eq!(<B as CheckedShr>::checked_shr(&b(4), 1u32), Some(b(2)));
+                assert_eq!(<B as CheckedShr>::checked_shr(&b(4), 2u32), None);
             }
         }
     } pub use self::$inner::Bounded as $name; )* }

--- a/src/types.rs
+++ b/src/types.rs
@@ -83,6 +83,29 @@ macro_rules! impl_bin_op {
     };
 }
 
+macro_rules! impl_shift_bin_op {
+    (u32, $op:ident::$method:ident/$op_assign:ident::$method_assign:ident, $desc:literal) => {
+        impl_bin_op!($op::$method/$op_assign::$method_assign, $desc);
+    };
+    ($inner:ident, $op:ident::$method:ident/$op_assign:ident::$method_assign:ident, $desc:literal) => {
+        impl_bin_op!($op::$method/$op_assign::$method_assign, $desc);
+
+        // Implementation used by checked shift operations
+        impl<const MIN: Inner, const MAX: Inner> $op<u32> for Bounded<MIN, MAX> {
+            type Output = Self;
+            #[inline]
+            fn $method(self, rhs: u32) -> Self::Output {
+                Self::new(self.get().$method(rhs))
+                    .expect(concat!("Attempted to ", $desc, " out of range"))
+            }
+        }
+        bin_op_variations!(
+            [const MIN: Inner, const MAX: Inner]
+            Bounded<MIN, MAX>, u32, $op::$method/$op_assign::$method_assign
+        );
+    };
+}
+
 #[cfg(test)]
 macro_rules! test_arithmetic {
     (ops($($op:tt $op_assign:tt)*) infallibles($($infallible:ident)*) fallibles($($fallible:ident)*)) => {
@@ -478,6 +501,26 @@ macro_rules! define_bounded_integers {
             pub const fn saturating_pow(self, rhs: u32) -> Self {
                 Self::new_saturating(self.get().saturating_pow(rhs))
             }
+
+            /// Checked shift left.
+            #[must_use]
+            #[inline]
+            pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
+                match self.get().checked_shl(rhs) {
+                    Some(val) => Self::new(val),
+                    None => None,
+                }
+            }
+
+            /// Checked shift right.
+            #[must_use]
+            #[inline]
+            pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
+                match self.get().checked_shr(rhs) {
+                    Some(val) => Self::new(val),
+                    None => None,
+                }
+            }
         }
 
         // === Operators ===
@@ -490,6 +533,8 @@ macro_rules! define_bounded_integers {
         impl_bin_op!(BitAnd::bitand/BitAndAssign::bitand_assign, "binary and");
         impl_bin_op!(BitOr::bitor/BitOrAssign::bitor_assign, "binary or");
         impl_bin_op!(BitXor::bitxor/BitXorAssign::bitxor_assign, "binary xor");
+        impl_shift_bin_op!($inner, Shl::shl/ShlAssign::shl_assign, "shift left");
+        impl_shift_bin_op!($inner, Shr::shr/ShrAssign::shr_assign, "shift right");
 
         $($(if $signed)?
             use core::ops::Neg;
@@ -928,6 +973,22 @@ macro_rules! define_bounded_integers {
         impl<const MIN: Inner, const MAX: Inner> num_traits02::CheckedRem for Bounded<MIN, MAX> {
             fn checked_rem(&self, v: &Self) -> Option<Self> {
                 Self::checked_rem(*self, v.get())
+            }
+        }
+
+        #[cfg(feature = "num-traits02")]
+        #[cfg_attr(doc_cfg, doc(cfg(feature = "num-traits02")))]
+        impl<const MIN: Inner, const MAX: Inner> num_traits02::CheckedShl for Bounded<MIN, MAX> {
+            fn checked_shl(&self, v: u32) -> Option<Self> {
+                Self::checked_shl(*self, v)
+            }
+        }
+
+        #[cfg(feature = "num-traits02")]
+        #[cfg_attr(doc_cfg, doc(cfg(feature = "num-traits02")))]
+        impl<const MIN: Inner, const MAX: Inner> num_traits02::CheckedShr for Bounded<MIN, MAX> {
+            fn checked_shr(&self, v: u32) -> Option<Self> {
+                Self::checked_shr(*self, v)
             }
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -487,6 +487,9 @@ macro_rules! define_bounded_integers {
         impl_bin_op!(Mul::mul/MulAssign::mul_assign, "multiply");
         impl_bin_op!(Div::div/DivAssign::div_assign, "divide");
         impl_bin_op!(Rem::rem/RemAssign::rem_assign, "take remainder");
+        impl_bin_op!(BitAnd::bitand/BitAndAssign::bitand_assign, "binary and");
+        impl_bin_op!(BitOr::bitor/BitOrAssign::bitor_assign, "binary or");
+        impl_bin_op!(BitXor::bitxor/BitXorAssign::bitxor_assign, "binary xor");
 
         $($(if $signed)?
             use core::ops::Neg;


### PR DESCRIPTION
This PR is an attempt from my side to add bitwise operations to the bounded integer crate. As far as I know and can see, these were not implemented. I do think that it is meaningful to add these. For example, a 3 bit field can be represented using a `BoundedU8<0, 7>`. By adding these implementations, typical bitwise operations on such field can be performed.

This PR adds the following:
- core::ops::{Not, BitAnd, BitOr, BitXor} and their corresponding `Assign` implementations for the predefined types.
- core::ops::{Shl, Shr} and their corresponding `Assign` implementations for the predefined types.
- core::ops::{Shl, Shr} and their corresponding `Assign` implementations for the predefined types using u32 as rhs. This is required by the `CheckedShl`/`CheckedShr` trait of numtraits (see https://docs.rs/num-traits/latest/num_traits/ops/checked/trait.CheckedShl.html)
- CheckedShl and CheckedShr implementation on Self for the predefined types.
- CheckedShl and CheckedShr unit test stuff
- core::ops::{Not, BitAnd, BitOr, BitXor, Shl, Shr} for the `generate` proc macro
- CheckedShl and CheckedShr for the `generate` proc macro

I have not yet tested these changes in any project. I expected to be able to do this in the coming few weeks (this is a side project, not so much time :( )