### PR TITLE
Add std::ops::Index on Vec, VecDeque and arrays for BoundedUsize

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1421,8 +1421,30 @@ impl<const MIN: usize, const MAX: usize, T> core::ops::Index<BoundedUsize<MIN, M
     }
 }
 
-#[cfg(all(test, feature = "std", feature = "types"))]
-mod usize2 {
+impl<const MIN: usize, const MAX: usize, T> core::ops::IndexMut<BoundedUsize<MIN, MAX>> for [T] {
+    #[inline]
+    fn index_mut(&mut self, index: BoundedUsize<MIN, MAX>) -> &mut Self::Output {
+        &mut self[index.get()]
+    }
+}
+#[cfg(feature = "std")]
+impl<const MIN: usize, const MAX: usize, T> core::ops::IndexMut<BoundedUsize<MIN, MAX>>
+    for std::vec::Vec<T>
+{
+    #[inline]
+    fn index_mut(&mut self, index: BoundedUsize<MIN, MAX>) -> &mut Self::Output {
+        &mut self[index.get()]
+    }
+}
+#[cfg(feature = "std")]
+impl<const MIN: usize, const MAX: usize, T> core::ops::IndexMut<BoundedUsize<MIN, MAX>>
+    for std::collections::VecDeque<T>
+{
+    #[inline]
+    fn index_mut(&mut self, index: BoundedUsize<MIN, MAX>) -> &mut Self::Output {
+        &mut self[index.get()]
+    }
+}
     #[test]
     fn indexing() {
         let vec = (0..20).collect::<std::vec::Vec<usize>>();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1390,10 +1390,7 @@ define_bounded_integers! {
 }
 
 //Indexing operations on [T; N], Vec<T> and VecDeque<T> for BoundedUsize
-#[cfg(all(feature = "std", feature = "types"))]
-impl<const MIN: usize, const MAX: usize, const N: usize, T> std::ops::Index<BoundedUsize<MIN, MAX>>
-    for [T; N]
-{
+impl<const MIN: usize, const MAX: usize, T> core::ops::Index<BoundedUsize<MIN, MAX>> for [T] {
     type Output = T;
 
     #[inline]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1388,3 +1388,51 @@ define_bounded_integers! {
     BoundedI64 i64 signed -> i64,
     BoundedIsize isize signed -> isize,
 }
+
+//Indexing operations on [T; N], Vec<T> and VecDeque<T> for BoundedUsize
+#[cfg(all(feature = "std", feature = "types"))]
+impl<const MIN: usize, const MAX: usize, const N: usize, T> std::ops::Index<BoundedUsize<MIN, MAX>> for [T; N] {
+    type Output = T;
+    
+    #[inline]
+    fn index(&self, index: BoundedUsize<MIN, MAX>) -> &Self::Output {
+        &self[index.get()]
+    }
+}
+
+#[cfg(all(feature = "std", feature = "types"))]
+impl<const MIN: usize, const MAX: usize, T> std::ops::Index<BoundedUsize<MIN, MAX>> for std::vec::Vec<T> {
+    type Output = T;
+    
+    #[inline]
+    fn index(&self, index: BoundedUsize<MIN, MAX>) -> &Self::Output {
+        &self[index.get()]
+    }
+}
+
+#[cfg(all(feature = "std", feature = "types"))]
+impl<const MIN: usize, const MAX: usize, T> std::ops::Index<BoundedUsize<MIN, MAX>> for std::collections::VecDeque<T> {
+    type Output = T;
+    
+    #[inline]
+    fn index(&self, index: BoundedUsize<MIN, MAX>) -> &Self::Output {
+        &self[index.get()]
+    }
+}
+
+#[cfg(all(test, feature = "std", feature = "types"))]
+mod tests {
+    #[test]
+    fn indexing() {
+        let vec = (0..20).collect::<std::vec::Vec<usize>>();
+        let arr: [_; 20] = vec.clone().try_into().unwrap();
+        let deq = vec.clone().into_iter().rev().collect::<std::collections::VecDeque<_>>();
+
+        for i in 0..20 {
+            let b_u = crate::types::BoundedUsize::<0, 20>::new(i).unwrap();
+            assert_eq!(vec[b_u], i);
+            assert_eq!(arr[b_u], i);
+            assert_eq!(deq[b_u], 19 - i);
+        }
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1398,9 +1398,8 @@ impl<const MIN: usize, const MAX: usize, T> core::ops::Index<BoundedUsize<MIN, M
         &self[index.get()]
     }
 }
-
-#[cfg(all(feature = "std", feature = "types"))]
-impl<const MIN: usize, const MAX: usize, T> std::ops::Index<BoundedUsize<MIN, MAX>>
+#[cfg(feature = "std")]
+impl<const MIN: usize, const MAX: usize, T> core::ops::Index<BoundedUsize<MIN, MAX>>
     for std::vec::Vec<T>
 {
     type Output = T;
@@ -1410,9 +1409,8 @@ impl<const MIN: usize, const MAX: usize, T> std::ops::Index<BoundedUsize<MIN, MA
         &self[index.get()]
     }
 }
-
-#[cfg(all(feature = "std", feature = "types"))]
-impl<const MIN: usize, const MAX: usize, T> std::ops::Index<BoundedUsize<MIN, MAX>>
+#[cfg(feature = "std")]
+impl<const MIN: usize, const MAX: usize, T> core::ops::Index<BoundedUsize<MIN, MAX>>
     for std::collections::VecDeque<T>
 {
     type Output = T;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1445,21 +1445,67 @@ impl<const MIN: usize, const MAX: usize, T> core::ops::IndexMut<BoundedUsize<MIN
         &mut self[index.get()]
     }
 }
+
+mod indexing_tests {
     #[test]
     fn indexing() {
+        let arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+        for i in 0..arr.len() {
+            let b_u = crate::types::BoundedUsize::<0, 30>::new(i).unwrap();
+            assert_eq!(arr[b_u], i);
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn indexing_std() {
         let vec = (0..20).collect::<std::vec::Vec<usize>>();
-        let arr: [_; 20] = vec.clone().try_into().unwrap();
         let deq = vec
             .clone()
             .into_iter()
             .rev()
             .collect::<std::collections::VecDeque<_>>();
 
-        for i in 0..20 {
-            let b_u = crate::types::BoundedUsize::<0, 20>::new(i).unwrap();
+        for i in 0..vec.len() {
+            let b_u = crate::types::BoundedUsize::<0, 30>::new(i).unwrap();
+
             assert_eq!(vec[b_u], i);
-            assert_eq!(arr[b_u], i);
             assert_eq!(deq[b_u], 19 - i);
+        }
+    }
+
+    #[test]
+    fn indexing_mut() {
+        let mut arr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+        for i in 0..arr.len() {
+            let b_u = crate::types::BoundedUsize::<0, 30>::new(i).unwrap();
+
+            arr[b_u] += 5;
+
+            assert_eq!(arr[b_u], i + 5);
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn indexing_mut_std() {
+        let mut vec = (0..20).collect::<std::vec::Vec<usize>>();
+        let mut deq = vec
+            .clone()
+            .into_iter()
+            .rev()
+            .collect::<std::collections::VecDeque<_>>();
+
+        for i in 0..vec.len() {
+            let b_u = crate::types::BoundedUsize::<0, 30>::new(i).unwrap();
+
+            vec[b_u] += 5;
+            deq[b_u] += 10;
+
+            assert_eq!(vec[b_u], i + 5);
+            assert_eq!(deq[b_u], (19 - i) + 10);
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1391,9 +1391,11 @@ define_bounded_integers! {
 
 //Indexing operations on [T; N], Vec<T> and VecDeque<T> for BoundedUsize
 #[cfg(all(feature = "std", feature = "types"))]
-impl<const MIN: usize, const MAX: usize, const N: usize, T> std::ops::Index<BoundedUsize<MIN, MAX>> for [T; N] {
+impl<const MIN: usize, const MAX: usize, const N: usize, T> std::ops::Index<BoundedUsize<MIN, MAX>>
+    for [T; N]
+{
     type Output = T;
-    
+
     #[inline]
     fn index(&self, index: BoundedUsize<MIN, MAX>) -> &Self::Output {
         &self[index.get()]
@@ -1401,9 +1403,11 @@ impl<const MIN: usize, const MAX: usize, const N: usize, T> std::ops::Index<Boun
 }
 
 #[cfg(all(feature = "std", feature = "types"))]
-impl<const MIN: usize, const MAX: usize, T> std::ops::Index<BoundedUsize<MIN, MAX>> for std::vec::Vec<T> {
+impl<const MIN: usize, const MAX: usize, T> std::ops::Index<BoundedUsize<MIN, MAX>>
+    for std::vec::Vec<T>
+{
     type Output = T;
-    
+
     #[inline]
     fn index(&self, index: BoundedUsize<MIN, MAX>) -> &Self::Output {
         &self[index.get()]
@@ -1411,9 +1415,11 @@ impl<const MIN: usize, const MAX: usize, T> std::ops::Index<BoundedUsize<MIN, MA
 }
 
 #[cfg(all(feature = "std", feature = "types"))]
-impl<const MIN: usize, const MAX: usize, T> std::ops::Index<BoundedUsize<MIN, MAX>> for std::collections::VecDeque<T> {
+impl<const MIN: usize, const MAX: usize, T> std::ops::Index<BoundedUsize<MIN, MAX>>
+    for std::collections::VecDeque<T>
+{
     type Output = T;
-    
+
     #[inline]
     fn index(&self, index: BoundedUsize<MIN, MAX>) -> &Self::Output {
         &self[index.get()]
@@ -1426,7 +1432,11 @@ mod usize2 {
     fn indexing() {
         let vec = (0..20).collect::<std::vec::Vec<usize>>();
         let arr: [_; 20] = vec.clone().try_into().unwrap();
-        let deq = vec.clone().into_iter().rev().collect::<std::collections::VecDeque<_>>();
+        let deq = vec
+            .clone()
+            .into_iter()
+            .rev()
+            .collect::<std::collections::VecDeque<_>>();
 
         for i in 0..20 {
             let b_u = crate::types::BoundedUsize::<0, 20>::new(i).unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1421,7 +1421,7 @@ impl<const MIN: usize, const MAX: usize, T> std::ops::Index<BoundedUsize<MIN, MA
 }
 
 #[cfg(all(test, feature = "std", feature = "types"))]
-mod tests {
+mod usize2 {
     #[test]
     fn indexing() {
         let vec = (0..20).collect::<std::vec::Vec<usize>>();


### PR DESCRIPTION
Found using `.get()` works too but this feels a bit more ergonomic. I briefly thought about putting it as a blanket implementation in the macro for all unsigned types but since rust doesn't allow you to do that I figured I wouldn't either - you guys can feel free to change as you see fit. I also added a little test, under `mod usize2` as I don't think you can't use the same module name twice. Currently it's behind the `types` and the `std` features as `Index` is std and `BoundedUsize` is within `types`