### PR TITLE
Allow byte literals in macro

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -437,6 +437,7 @@ impl Display for ReprSizeFixed {
 fn eval_expr(expr: &Expr) -> syn::Result<BigInt> {
     Ok(match expr {
         Expr::Lit(ExprLit { lit, .. }) => match lit {
+            Lit::Byte(byte) => byte.value().into(),
             Lit::Int(int) => int.base10_parse()?,
             _ => {
                 return Err(Error::new_spanned(lit, "literal must be integer"));


### PR DESCRIPTION
This doesn't do the probably better option of forbidding the mixing of these with larger integer types or bounding the size to `u8`, but it at least allows for using `bounded_integer!` for narrowing down ASCII characters.